### PR TITLE
Cache node_modules in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install the dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install
       - name: Build the extension
         run: npx vsce package
@@ -62,7 +70,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install the dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install
       - name: Lint
         run: yarn lint -f ./node_modules/@firmnav/eslint-github-actions-formatter/dist/formatter.js


### PR DESCRIPTION
As title. Make it run faster :)

All runs with identical `yarn.lock` will restore cached `node_modules`.

Example:
![image](https://user-images.githubusercontent.com/33488131/111888184-185fc880-89d2-11eb-89a0-e9d17f0699d7.png)
